### PR TITLE
alb.xml: switch to new GitHub URLs

### DIFF
--- a/alb.xml
+++ b/alb.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
   <manifest>
-  <remote fetch="https://source.codeaurora.org/external/autobsps32" name="alb"/>
+  <remote fetch="https://github.com/nxp-auto-linux/" name="alb"/>
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
   <remote fetch="https://git.openembedded.org" name="oe"/>
   <remote fetch="https://git.linaro.org/openembedded" name="linaro"/>
 
-  <remote fetch="https://source.codeaurora.org/external/qoriq" name="qoriq"/>
+  <remote fetch="https://github.com/nxp-qoriq" name="qoriq"/>
 
   <!-- The default revision and remote are applicable to the meta-alb layer -->
   <default sync-j="2" revision="594f3e8aa18bcc76b9f494d4462a819a92ba12b7" remote="alb"/>
@@ -25,6 +25,6 @@
 
 
   <!-- projects below are not updated for gatesgarth -->
-  <project name="qoriq-components/meta-qoriq" path="sources/meta-qoriq" remote="qoriq" revision="e381f3eb56b75a4f5f54092952cbb30d8ae8cbcf" upstream="dunfell"/>
+  <project name="meta-qoriq" path="sources/meta-qoriq" remote="qoriq" revision="e381f3eb56b75a4f5f54092952cbb30d8ae8cbcf" upstream="dunfell"/>
 
   </manifest>


### PR DESCRIPTION
This updates the outdated and non-functional codeaurora.org URLs to the new GitHub-based URLs

Fixes #1 